### PR TITLE
Improve Xdebug support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ public
 wp-config-local.php
 wp-tests-config-local.php
 wp-cli.local.yml
+
+# This file is added by xdebug-on.sh; when present, Xdebug is re-enabled
+# after rebuilding.
+.xdebug-enabled

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -29,6 +29,10 @@ env_file:
 
 services:
   appserver:
+    overrides:
+      environment:
+        # Support debugging with XDEBUG.
+        PHP_IDE_CONFIG: "serverName=wordpressdev.lndo.site"
     composer:
       # Note installing phpunit should be temporary because core should really install it via composer on its own.
       phpunit/phpunit: "^6"

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -19,7 +19,7 @@ config:
   via: nginx
   webroot: public
   database: mariadb
-  xdebug: true
+  xdebug: false # This needs to be false initially because otherwise provisioning takes much longer.
   config:
     php: php.ini
 

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -19,7 +19,9 @@ config:
   via: nginx
   webroot: public
   database: mariadb
-  xdebug: false
+  xdebug: true
+  config:
+    php: php.ini
 
 env_file:
   - .env.base

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -38,6 +38,8 @@ services:
       - echo "127.0.0.1  wordpressdev.lndo.site" >> /etc/hosts
     run:
       - bash bin/setup-wordpress.sh
+    run_as_root:
+      - bash /app/bin/xdebug-resume.sh
 
 tooling:
   npm:
@@ -62,6 +64,16 @@ tooling:
     service: appserver
   log:
     service: appserver
-    cmd: "bash /app/bin/tail-php-error-log.sh"
+    cmd: bash /app/bin/tail-php-error-log.sh
   wp:
     service: appserver
+  xdebug-on:
+    service: appserver
+    description: Enable Xdebug for nginx.
+    cmd: bash /app/bin/xdebug-on.sh
+    user: root
+  xdebug-off:
+    service: appserver
+    description: Disable Xdebug for nginx.
+    cmd: bash /app/bin/xdebug-off.sh
+    user: root

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -20,7 +20,7 @@ if [[ -z "$LANDO_MOUNT" ]]; then
 fi
 
 echo "Installing Dependencies"
-set -x
+set -xe
 
 apt-get update -y
 apt-get -y install libyaml-dev

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -20,6 +20,7 @@ if [[ -z "$LANDO_MOUNT" ]]; then
 fi
 
 echo "Installing Dependencies"
+set -x
 
 apt-get update -y
 apt-get -y install libyaml-dev

--- a/bin/xdebug-off.sh
+++ b/bin/xdebug-off.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+if [ -e /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ]; then
+  rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  pkill -o -USR2 php-fpm
+fi
+rm /app/.xdebug-enabled

--- a/bin/xdebug-off.sh
+++ b/bin/xdebug-off.sh
@@ -5,5 +5,11 @@ set -e
 if [ -e /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini ]; then
   rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
   pkill -o -USR2 php-fpm
+  echo "Xdebug disabled"
+else
+  echo "Xdebug already disabled"
 fi
-rm /app/.xdebug-enabled
+
+if [ -e /app/.xdebug-enabled ]; then
+  rm /app/.xdebug-enabled
+fi

--- a/bin/xdebug-on.sh
+++ b/bin/xdebug-on.sh
@@ -5,3 +5,4 @@ set -e
 docker-php-ext-enable xdebug
 pkill -o -USR2 php-fpm
 touch /app/.xdebug-enabled
+echo "Xdebug enabled"

--- a/bin/xdebug-on.sh
+++ b/bin/xdebug-on.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+docker-php-ext-enable xdebug
+pkill -o -USR2 php-fpm
+touch /app/.xdebug-enabled

--- a/bin/xdebug-resume.sh
+++ b/bin/xdebug-resume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+if [ -e /app/.xdebug-enabled ]; then
+  bash /app/bin/xdebug-on.sh
+fi

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,4 @@
+xdebug.remote_enable = 1
+xdebug.remote_autostart = 0
+xdebug.remote_connect_back = 1
+html_errors = 1

--- a/php.ini
+++ b/php.ini
@@ -1,5 +1,5 @@
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 0
 xdebug.remote_connect_back = 0
-xdebug.remote_port=9001
+xdebug.remote_port=9000
 html_errors = 1

--- a/php.ini
+++ b/php.ini
@@ -1,5 +1,5 @@
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 0
-xdebug.remote_connect_back = 1
+xdebug.remote_connect_back = 0
 xdebug.remote_port=9001
 html_errors = 1

--- a/php.ini
+++ b/php.ini
@@ -1,4 +1,5 @@
 xdebug.remote_enable = 1
 xdebug.remote_autostart = 0
 xdebug.remote_connect_back = 1
+xdebug.remote_port=9001
 html_errors = 1


### PR DESCRIPTION
The intention of this PR is to improve the ability to use Xdebug in order to do remote debugging and profiling, among other capabilities.

- [x] Try to provide mechanism for toggling Xdebug more easily (like [`xdebug_on`](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/config/homebin/xdebug_on) and [`xdebug_off`](https://github.com/Varying-Vagrant-Vagrants/VVV/blob/develop/config/homebin/xdebug_off)), since just enabling the xdebug increases PHP execution time by 100% (which is unacceptable).

# Setup with IntelliJ/PhpStorm

1. Add `wordpressdev.lndo.site` server (using the domain as both Name and Host) under **Languages & Frameworks > PHP > Servers**, making sure that the root directory on the host (where the `.lando.base.yml` file is located) is mapped to `/app`:

![image](https://user-images.githubusercontent.com/134745/86546164-3343e880-bee8-11ea-81b4-7088216a8a85.png)

2. Now under **Languages & Frameworks > PHP > Debug**, make sure that the debug port is set to 9000:

![image](https://user-images.githubusercontent.com/134745/86625698-59b26400-bf7a-11ea-8c89-744ec87da2bd.png)

3. Under the **Run** menu, go to **Edit Configurations…**. Click the + icon to create a **PHP Remote Debug** configuration. Select the `wordpressdev.lndo.site` server you created in step 1. Then provide an IDE key, the value of which apparently does not matter:

![image](https://user-images.githubusercontent.com/134745/86551187-3693a000-bef9-11ea-9c9f-5b2d87278535.png)

4. Then to start debugging, run `lando xdebug-on` from the command line to enable Xdebug. Then click the phone icon in the toolbar to Start Listening for Debug Connections:

![image](https://user-images.githubusercontent.com/134745/86546434-c03b7180-bee9-11ea-9138-c6d4e0af5299.png)

Upon clicking, the icon will look like this when active: 

![image](https://user-images.githubusercontent.com/134745/86546463-e2cd8a80-bee9-11ea-93e0-5c7cd7a50f2c.png)

5. You may now set a breakpoint in the editor by clicking in the gutter (or you can use the `xdebug_break()` function to the same):

![image](https://user-images.githubusercontent.com/134745/86546498-0ee90b80-beea-11ea-91ff-62c42aabb676.png)

6. Now load the page in the browser and the execution should stop at the breakpoint:

![image](https://user-images.githubusercontent.com/134745/86546548-54a5d400-beea-11ea-9f67-f83e2165c10b.png)

# Resources

* [LANDO + PHPSTORM + XDEBUG](https://docs.devwithlando.io/guides/lando-phpstorm.html)
* [Toggling Xdebug](https://docs.devwithlando.io/tutorials/php.html#toggling-xdebug)
* https://xdebug.org/docs/remote
* [Configuring Xdebug for Lando](https://www.timjensen.us/configuring-xdebug-for-lando/)