### PR TITLE
Update Node from v10 to v11

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -28,7 +28,7 @@ echo 'extension=yaml.so' > /usr/local/etc/php/conf.d/yaml.ini
 
 apt-get install gnupg -y
 
-curl -sL https://deb.nodesource.com/setup_10.x | bash -
+curl -sL https://deb.nodesource.com/setup_11.x | bash -
 apt-get install nodejs -y
 
 curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
After doing `npm install` on a plugin project I often see issues with the `package-lock.json` having differences with `optional` being toggled. This is something that appears to be fixed in npm 6.6: https://github.com/renovatebot/renovate/issues/2294

Node 10 includes npm 6.4 whereas Node 11 includes npm 6.7, so if we update from 10 to 11 that should fix this issue.