### PR TITLE
Bump Node.js from 11 to 12

### DIFF
--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -28,7 +28,7 @@ echo 'extension=yaml.so' > /usr/local/etc/php/conf.d/yaml.ini
 
 apt-get install gnupg -y
 
-curl -sL https://deb.nodesource.com/setup_11.x | bash -
+curl -sL https://deb.nodesource.com/setup_12.x | bash -
 apt-get install nodejs -y
 
 curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -


### PR DESCRIPTION
When attempting to build Gutenberg, I got an error:

```
> gutenberg@7.4.0 prebuild /app/public/content/plugins/gutenberg
> npm run check-engines


> gutenberg@7.4.0 check-engines /app/public/content/plugins/gutenberg
> wp-scripts check-engines

npm: 6.7.0
Error: Wanted npm version >=6.9.0 (>=6.9.0)
To install npm, run `npm install -g npm@>=6.9.0`
```

This is fixed by updating the version of Node. 
