### PR TITLE
Set WP_DEBUG_LOG to file in /tmp

### DIFF
--- a/bin/tail-php-error-log.sh
+++ b/bin/tail-php-error-log.sh
@@ -14,10 +14,13 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
 
-if [[ ! -e /app/public/content/debug.log ]]; then
-    touch /app/public/content/debug.log
+# See WP_DEBUG_LOG in wp-config.php.
+ERROR_LOG_PATH="/tmp/php-error.log"
+
+if [[ ! -e "$ERROR_LOG_PATH" ]]; then
+    touch "$ERROR_LOG_PATH"
 fi
 
-echo 'Assuming WP_DEBUG_LOG enabled, tailing /app/public/content/debug.log...'
+echo "Assuming WP_DEBUG_LOG defined and set to $ERROR_LOG_PATH..."
 
-tail -f /app/public/content/debug.log
+tail -f "$ERROR_LOG_PATH"

--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -52,7 +52,7 @@ $constants = array(
 
 	'FORCE_SSL_ADMIN'                => true,
 	'WP_DEBUG'                       => true,
-	'WP_DEBUG_LOG'                   => true,
+	'WP_DEBUG_LOG'                   => '/tmp/php-error.log',
 	'WP_DISABLE_FATAL_ERROR_HANDLER' => true,
 	'JETPACK_DEV_DEBUG'              => true,
 );


### PR DESCRIPTION
By setting `WP_DEBUG_LOG` to `true`, PHP error log was writing out to `content/debug.log`. This is problematic for two reasons:

1. The file will keep growing forever.
2. Each write to the log will require propagation from the container to the host (e.g. on macOS), which can be slow.

These issues can be mitigated by writing to a log file that is in `/tmp` instead of to a file inside of `/app`.

Tailing the error log can still be done just via `lando log`.