### PR TITLE
Define WP_ENVIRONMENT_TYPE as development

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -55,6 +55,7 @@ $constants = array(
 	'WP_DEBUG_LOG'                   => '/tmp/php-error.log',
 	'WP_DISABLE_FATAL_ERROR_HANDLER' => true,
 	'JETPACK_DEV_DEBUG'              => true,
+	'WP_ENVIRONMENT_TYPE'            => 'development',
 );
 foreach ( $constants as $constant_name => $constant_value ) {
 	if ( ! defined( $constant_name ) ) {


### PR DESCRIPTION
See https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/