### PR TITLE
Add wildcard subdomain to proxy config, remove obsolete /etc/hosts amending, and add bin/install-local-dependencies.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ wp-cli.local.yml
 # This file is added by xdebug-on.sh; when present, Xdebug is re-enabled
 # after rebuilding.
 .xdebug-enabled
+
+# Ignored file allowing for additional dependencies to be installed.
+/bin/install-local-dependencies.sh

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -43,8 +43,6 @@ services:
       phpunit/phpunit: "^6"
     install_dependencies_as_root:
       - bash bin/install-dependencies.sh
-      # Allow loopback requests to work.
-      - echo "127.0.0.1  wordpressdev.lndo.site" >> /etc/hosts
     run:
       - bash bin/setup-wordpress.sh
     run_as_root:

--- a/.lando.base.yml
+++ b/.lando.base.yml
@@ -27,6 +27,11 @@ env_file:
   - .env.base
   - .env
 
+proxy:
+  appserver_nginx:
+    - wordpressdev.lndo.site
+    - "*.wordpressdev.lndo.site"
+
 services:
   appserver:
     overrides:

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -44,3 +44,8 @@ apt-get install yarn -y
 
 apt-get install zip -y
 apt-get install subversion -y
+
+# Install dependencies that are unique to the user environment.
+if [ -e install-local-dependencies.sh ]; then
+	bash ./install-local-dependencies.sh
+fi

--- a/bin/install-dependencies.sh
+++ b/bin/install-dependencies.sh
@@ -19,13 +19,18 @@ if [[ -z "$LANDO_MOUNT" ]]; then
     exit 1
 fi
 
+cd "$(dirname "$0")"
+
 echo "Installing Dependencies"
 set -xe
 
 apt-get update -y
 apt-get -y install libyaml-dev
-yes | pecl install yaml
-echo 'extension=yaml.so' > /usr/local/etc/php/conf.d/yaml.ini
+if yes | pecl install yaml; then
+	echo 'extension=yaml.so' > /usr/local/etc/php/conf.d/yaml.ini
+else
+	echo "Did not install yaml."
+fi
 
 apt-get install gnupg -y
 


### PR DESCRIPTION
* Add a `proxy` alias for `*.wordpressdev.lndo.site` so that any subdomains under `wordpressdev.lndo.site` will be recognized. There is one outstanding problem here where loopback requests for these subdomains does not work, but I believe that is an issue with Lando.
* Remove amending `/etc/hosts` with the `wordpressdev.lndo.site` hostname since this appears now to be obsolete. Lando is taking care of it. I can perform loopback requests even with it not added.
* Lastly, introduce a `.gitignore`'d `bin/install-local-dependencies.sh` which can facilitate you adding additional dependencies to an environment without causing a dirty repo state.