### PR TITLE
Bump `NODE_MAJOR` to 20

### DIFF
--- a/.env.base
+++ b/.env.base
@@ -22,7 +22,7 @@ WP_CORE_DIR=/app/public/core-dev/build/
 WP_TESTS_DIR=/app/public/core-dev/tests/phpunit/
 
 # Node version to use globally
-NODE_MAJOR=16
+NODE_MAJOR=20
 
 # PHPUnit version to use globally
 PHPUNIT_MAJOR=9


### PR DESCRIPTION
- Bump Nodejs version to 20, since latest WP uses it.